### PR TITLE
Refactor admin URL path for improved routing consistency

### DIFF
--- a/back_end/bakery/urls.py
+++ b/back_end/bakery/urls.py
@@ -22,7 +22,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name='index.html')),
-    path('backend/admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
     path('backend/user/', include('user.urls')),
     path('backend/order/', include('order.urls'))
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Change the admin URL path from 'backend/admin/' to 'admin/' to enhance routing clarity and consistency.